### PR TITLE
Fix switching back to non-spanning not working for web components.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -144,8 +144,6 @@ function insertSpanningStyles(element) {
   }
   let configs = window[POLYFILL_NAMESPACE];
 
-  if (configs.spanning === SPANNING_MF_VAL_NONE) return;
-
   let spanningCSSText = element ?
     spanning[element.nodeName.toLowerCase()][configs.spanning] :
     spanning[configs.spanning];


### PR DESCRIPTION
No need to early bail out, we need to load the original style.